### PR TITLE
(Feature): Allow an additional JS file to be passed to SC to have it …

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ SocketCluster.prototype._init = function (options) {
     tcpSynBacklog: null,
     workerController: null,
     brokerController: null,
+    initController: null,
     rebootOnSignal: true,
     downgradeToUser: false,
     path: null,
@@ -137,8 +138,14 @@ SocketCluster.prototype._init = function (options) {
   self._paths = {
     appDirPath: appDirPath,
     statusURL: '/~status',
-    appWorkerControllerPath: path.resolve(self.options.workerController)
+    appWorkerControllerPath: path.resolve(self.options.workerController),
   };
+
+  if(self.options.initController) {
+      self._paths.appInitControllerPath = path.resolve(self.options.initController);
+  } else {
+      self._paths.appInitControllerPath = null;
+  }
 
   var pathHasher = crypto.createHash('md5');
   pathHasher.update(self._paths.appDirPath, 'utf8');
@@ -557,7 +564,8 @@ SocketCluster.prototype._start = function () {
       downgradeToUser: self.options.downgradeToUser,
       processTermTimeout: self.options.processTermTimeout,
       brokerOptions: self.options,
-      appBrokerControllerPath: self._paths.appBrokerControllerPath
+      appBrokerControllerPath: self._paths.appBrokerControllerPath,
+      appInitControllerPath: self._paths.appInitControllerPath
     });
 
     self._ioCluster.on('error', function (err) {

--- a/lib/scworker.js
+++ b/lib/scworker.js
@@ -219,6 +219,12 @@ SCWorker.prototype._start = function () {
   }
   this._statusInterval = setInterval(this._calculateStatus.bind(this), this.options.workerStatusInterval);
 
+  // Run the initController to initialize the global context
+  if(this._paths.appInitControllerPath != null) {
+      this._initController = require(this._paths.appInitControllerPath);
+      this._initController.run(this);
+  }
+
   this._workerController = require(this._paths.appWorkerControllerPath);
   this._workerController.run(this);
 

--- a/sample/init.js
+++ b/sample/init.js
@@ -1,0 +1,3 @@
+module.exports.run = function(SC) {
+    console.log('   >> Initializing process of PID:', process.pid);
+}

--- a/sample/server.js
+++ b/sample/server.js
@@ -1,5 +1,5 @@
 var argv = require('minimist')(process.argv.slice(2));
-var SocketCluster = require('socketcluster').SocketCluster;
+var SocketCluster = require('../').SocketCluster;
 
 var socketCluster = new SocketCluster({
   workers: Number(argv.w) || 1,
@@ -8,6 +8,7 @@ var socketCluster = new SocketCluster({
   appName: argv.n || null,
   workerController: __dirname + '/worker.js',
   brokerController: __dirname + '/broker.js',
+  initController: __dirname +'/init.js',
   socketChannelLimit: 1000,
   rebootWorkerOnCrash: argv['auto-reboot'] != false
 });


### PR DESCRIPTION
…modify the global scope.

This is essentially useful for:
- Using JavaScript dialects in workers.
- Applying various patches to the global scope.
- Short-circuiting the application if a cruicial error is found.
- Sharing initializing code with Broker processes, reducing duplicated code.

The proper ioCluster and nData PRs are on their way.

Also, within the samples, the require statement was changed to require the next top-level folder. I saw this iseful for testing, but I'd forgotten to change it back once I was done. Feel free to leave it in if you'd like.