### PR TITLE
keep buffers as buffers

### DIFF
--- a/lib/workercluster.js
+++ b/lib/workercluster.js
@@ -177,7 +177,7 @@ if (cluster.isMaster) {
       }
       
       if (typeof m.data.authKey === 'object' && m.data.authkey !== null && m.data.authKey.type === 'Buffer') {
-        m.data.authKey = new Buffer(m.data.authKey.data);
+        m.data.authKey = new Buffer(m.data.authKey.data, 'base64');
       }
       
       global.worker = worker = new SCWorker(m.data);

--- a/lib/workercluster.js
+++ b/lib/workercluster.js
@@ -175,7 +175,11 @@ if (cluster.isMaster) {
       if (m.data && m.data.protocolOptions && m.data.protocolOptions.pfx) {
         m.data.protocolOptions.pfx = new Buffer(m.data.protocolOptions.pfx, 'base64');
       }
-
+      
+      if (typeof m.data.authKey === 'object' && m.data.authkey !== null && m.data.authKey.type === 'Buffer') {
+        m.data.authKey = new Buffer(m.data.authKey.data);
+      }
+      
       global.worker = worker = new SCWorker(m.data);
 
       if (m.data.propagateErrors) {


### PR DESCRIPTION
fixes #168.
an authKey can be a buffer.
When it gets via the _workerCluster (message: 'init'), the buffer gets stringified & parsed back into an object representation of a buffer.
This rehydrates the buffer.

not sure about public/private keys, maybe they have the same problem?
Also, since security is at risk, it might be time to switch to `Buffer.from`, but that will require a recent version of node. 
https://nodejs.org/api/buffer.html