### PR TITLE
Fixes camelCase in authKey check in worker process on message listener

### DIFF
--- a/lib/workercluster.js
+++ b/lib/workercluster.js
@@ -181,7 +181,7 @@ if (cluster.isMaster) {
         m.data.protocolOptions.pfx = new Buffer(m.data.protocolOptions.pfx, 'base64');
       }
 
-      if (typeof m.data.authKey === 'object' && m.data.authkey !== null && m.data.authKey.type === 'Buffer') {
+      if (typeof m.data.authKey === 'object' && m.data.authKey !== null && m.data.authKey.type === 'Buffer') {
         m.data.authKey = new Buffer(m.data.authKey.data, 'base64');
       }
 


### PR DESCRIPTION
Upgrading from 4.3.0 to 5.0.11 throwing this error on startup. Using PEM file so authKey is null and have authPrivateKey and authPublicKey set. 

````
1473695906756 - Origin: Worker (PID 30273)
   [Error] TypeError: Cannot read property 'type' of null
    at process.<anonymous> (/home/repo/node_modules/socketcluster/lib/workercluster.js:186:90)
    at emitTwo (events.js:111:20)
    at process.emit (events.js:191:7)
    at process.EventEmitter.emit (/home/repo/node_modules/sc-domain/index.js:12:31)
    at handleMessage (internal/child_process.js:718:10)
    at Pipe.channel.onread (internal/child_process.js:444:11)
1473695906757 - Worker 0 exited - Exit code: 1
````

