### PR TITLE
add socketcluster-client as a dev dependency, for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "scalable"
   ],
   "license": "MIT",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "devDependencies": {
+    "socketcluster-client": "5.x.x"
+  }
 }


### PR DESCRIPTION
Fixes #152 , at least the problem with running the tests.

socketcluster-client wasn't in the package.json as a dependency.  If it is needed only for tests, it can be in the devDependencies.

Feel free to disregard this, do it some other way, etc, whatever works best for the project.

Thanks,
Victor