### PR TITLE
Add podAntiAffinity to socketcluster deployment

### DIFF
--- a/kubernetes/socketcluster-deployment.yaml
+++ b/kubernetes/socketcluster-deployment.yaml
@@ -33,3 +33,13 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 5
+  affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - socketcluster
+            topologyKey: "kubernetes.io/hostname"

--- a/scc-guide.md
+++ b/scc-guide.md
@@ -112,3 +112,5 @@ Nevertheless, it is recommended that you run the **scc-state** instance inside y
 The **scc-state** instance does not handle any pub/sub messages and so it is not a bottleneck with regards to the scalability of your cluster (SCC scales linearly).
 
 Note that you can launch the services in any order you like but if your state server is not available, you may get harmless `Socket hung up` warnings on other instances (while they keep trying to reconnect) until **scc-state** becomes available again.
+
+The **socketcluster** deployment in https://github.com/SocketCluster/socketcluster/kubernetes/ uses podAntiAffinity rule to ensure only one socketcluster instance is scheduled for any given kubernetes node. This may be preferred, since we want to run on as many cores as possible.


### PR DESCRIPTION
Uses standard labels that should be available for all k8s environments (https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/#tolerating-node-failure)