### PR TITLE
Added forceKillTimeout options

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ SocketCluster.prototype._init = function (options) {
     socketChannelLimit: 1000,
     workerStatusInterval: 10000,
     processTermTimeout: 10000,
-    forceKillTimeout:15000,
+    forceKillTimeout: 15000,
     propagateErrors: true,
     propagateWarnings: true,
     middlewareEmitWarnings: true,

--- a/index.js
+++ b/index.js
@@ -788,7 +788,7 @@ SocketCluster.prototype._start = function () {
     secretKey: self.options.secretKey,
     expiryAccuracy: self._dataExpiryAccuracy,
     downgradeToUser: self.options.downgradeToUser,
-    processTermTimeout: self.options.processTermTimeout,    
+    processTermTimeout: self.options.processTermTimeout,
     forceKillTimeout: self.options.forceKillTimeout,
     forceKillSignal:self.options.forceKillSignal,
     ipcAckTimeout: self.options.ipcAckTimeout,

--- a/index.js
+++ b/index.js
@@ -790,7 +790,7 @@ SocketCluster.prototype._start = function () {
     downgradeToUser: self.options.downgradeToUser,
     processTermTimeout: self.options.processTermTimeout,
     forceKillTimeout: self.options.forceKillTimeout,
-    forceKillSignal:self.options.forceKillSignal,
+    forceKillSignal: self.options.forceKillSignal,
     ipcAckTimeout: self.options.ipcAckTimeout,
     brokerOptions: self.options,
     appBrokerControllerPath: self._paths.appBrokerControllerPath

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ SocketCluster.prototype._init = function (options) {
     workerStatusInterval: 10000,
     processTermTimeout: 10000,
     forceKillTimeout: 15000,
+    forceKillSignal:'SIGHUP',
     propagateErrors: true,
     propagateWarnings: true,
     middlewareEmitWarnings: true,
@@ -787,8 +788,9 @@ SocketCluster.prototype._start = function () {
     secretKey: self.options.secretKey,
     expiryAccuracy: self._dataExpiryAccuracy,
     downgradeToUser: self.options.downgradeToUser,
-    processTermTimeout: self.options.processTermTimeout,
+    processTermTimeout: self.options.processTermTimeout,    
     forceKillTimeout: self.options.forceKillTimeout,
+    forceKillSignal:self.options.forceKillSignal,
     ipcAckTimeout: self.options.ipcAckTimeout,
     brokerOptions: self.options,
     appBrokerControllerPath: self._paths.appBrokerControllerPath

--- a/index.js
+++ b/index.js
@@ -875,6 +875,7 @@ SocketCluster.prototype.sendToBroker = function (brokerId, data, callback) {
 
 // The options object is optional and can have two boolean fields:
 // immediate: Shut down the workers immediately without waiting for termination timeout.
+// killClusterMaster: Shut down the cluster master (load balancer) as well as all the workers.
 SocketCluster.prototype.killWorkers = function (options) {
   if (this.workerCluster) {
     this.workerCluster.send({

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ SocketCluster.prototype._init = function (options) {
     workerStatusInterval: 10000,
     processTermTimeout: 10000,
     forceKillTimeout: 15000,
-    forceKillSignal:'SIGHUP',
+    forceKillSignal: 'SIGHUP',
     propagateErrors: true,
     propagateWarnings: true,
     middlewareEmitWarnings: true,

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ SocketCluster.prototype._init = function (options) {
     socketChannelLimit: 1000,
     workerStatusInterval: 10000,
     processTermTimeout: 10000,
+    forceKillTimeout:15000,
     propagateErrors: true,
     propagateWarnings: true,
     middlewareEmitWarnings: true,
@@ -165,6 +166,7 @@ SocketCluster.prototype._init = function (options) {
   verifyDuration('pingTimeout');
   verifyDuration('workerStatusInterval');
   verifyDuration('processTermTimeout');
+  verifyDuration('forceKillTimeout');
 
   if (self.options.appName == null) {
     self.options.appName = uuid.v4();
@@ -786,6 +788,7 @@ SocketCluster.prototype._start = function () {
     expiryAccuracy: self._dataExpiryAccuracy,
     downgradeToUser: self.options.downgradeToUser,
     processTermTimeout: self.options.processTermTimeout,
+    forceKillTimeout: self.options.forceKillTimeout,
     ipcAckTimeout: self.options.ipcAckTimeout,
     brokerOptions: self.options,
     appBrokerControllerPath: self._paths.appBrokerControllerPath
@@ -872,7 +875,6 @@ SocketCluster.prototype.sendToBroker = function (brokerId, data, callback) {
 
 // The options object is optional and can have two boolean fields:
 // immediate: Shut down the workers immediately without waiting for termination timeout.
-// killClusterMaster: Shut down the cluster master (load balancer) as well as all the workers.
 SocketCluster.prototype.killWorkers = function (options) {
   if (this.workerCluster) {
     this.workerCluster.send({

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -76,10 +76,8 @@ process.on('message', function (masterMessage) {
       setTimeout(function () {
         for (var i in workers) { 
           if (!childExitMessage[i]) {            
-            console.warn(forceKillTimeout + " ms no exit signal from Worker " + i + "(PID:"+workers[i].process.pid+') force kill it' );
-            //process.kill(workers[i].process.pid,'SIGINT')
-            process.kill(workers[i].process.pid,'SIGHUP') 
-            //process.kill(workers[i].process.pid,'SIGKILL')  
+            console.warn(forceKillTimeout + " ms no exit signal from Worker " + i + "(PID:"+workers[i].process.pid+') force kill it' );            
+            process.kill(workers[i].process.pid,'SIGHUP')
           }
         }
       }, forceKillTimeout)

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -4,7 +4,7 @@ var InvalidActionError = scErrors.InvalidActionError;
 
 var workerInitOptions = JSON.parse(process.env.workerInitOptions);
 var processTermTimeout = 10000;
-var forceKillTimeout =15000;
+var forceKillTimeout = 15000;
 
 process.on('disconnect', function () {
   process.exit();

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -5,6 +5,7 @@ var InvalidActionError = scErrors.InvalidActionError;
 var workerInitOptions = JSON.parse(process.env.workerInitOptions);
 var processTermTimeout = 10000;
 var forceKillTimeout = 15000;
+var forceKillSignal = 'SIGHUP';
 
 process.on('disconnect', function () {
   process.exit();
@@ -77,7 +78,7 @@ process.on('message', function (masterMessage) {
         for (var i in workers) {
           if (!childExitMessage[i]) {
             console.warn(forceKillTimeout + " ms no exit signal from Worker " + i + "(PID:"+workers[i].process.pid+') force kill it' );
-            process.kill(workers[i].process.pid,'SIGHUP')
+            process.kill(workers[i].process.pid,forceKillSignal)
           }
         }
       }, forceKillTimeout)
@@ -118,11 +119,14 @@ SCWorkerCluster.prototype._init = function (options) {
   if (options.schedulingPolicy != null) {
     cluster.schedulingPolicy = options.schedulingPolicy;
   }
-  if (options.processTermTimeout) {
+  if (options.processTermTimeout != null) {
     processTermTimeout = options.processTermTimeout;
   }
-  if (options.forceKillTimeout) {
+  if (options.forceKillTimeout != null) {
     forceKillTimeout = options.forceKillTimeout;
+  }
+  if (options.forceKillSignal != null) {
+    forceKillSignal = options.forceKillSignal;
   }
 
   cluster.setupMaster({

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -98,7 +98,7 @@ process.on('uncaughtException', function (err) {
 function SCWorkerCluster(options) {
   if (scWorkerCluster) {
     // SCWorkerCluster is a singleton; it can only be instantiated once per process.
-    throw new InvalidActionError('Attempted to instantiate a worker cluster which has already been instantiated'); 
+    throw new InvalidActionError('Attempted to instantiate a worker cluster which has already been instantiated');
   }
   options = options || {};
   scWorkerCluster = this;

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -16,7 +16,7 @@ var workers;
 var alive = true;
 var hasExited = false;
 var terminatedCount = 0;
-var childExitMessage;
+var childExitMessage={};
 
 var sendErrorToMaster = function (err) {
   var error = scErrors.dehydrateError(err, true);

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -111,7 +111,7 @@ function SCWorkerCluster(options) {
 }
 
 SCWorkerCluster.create = function (options) {
-  return new SCWorkerCluster(options); 
+  return new SCWorkerCluster(options);
 };
 
 SCWorkerCluster.prototype._init = function (options) {

--- a/scworkercluster.js
+++ b/scworkercluster.js
@@ -71,12 +71,12 @@ process.on('message', function (masterMessage) {
     if (masterMessage.type == 'terminate' && masterMessage.data.killClusterMaster) {
       terminate();
     }
-    if (masterMessage.type == 'terminate' && forceKillTimeout) {      
+    if (masterMessage.type == 'terminate' && forceKillTimeout) {
       childExitMessage = {}
       setTimeout(function () {
-        for (var i in workers) { 
-          if (!childExitMessage[i]) {            
-            console.warn(forceKillTimeout + " ms no exit signal from Worker " + i + "(PID:"+workers[i].process.pid+') force kill it' );            
+        for (var i in workers) {
+          if (!childExitMessage[i]) {
+            console.warn(forceKillTimeout + " ms no exit signal from Worker " + i + "(PID:"+workers[i].process.pid+') force kill it' );
             process.kill(workers[i].process.pid,'SIGHUP')
           }
         }


### PR DESCRIPTION
processTermTimeout will try to call process.exit() in the worker process after certain seconds of close event, this forceKillTimeout will try to call process.kill(worker.pid,SIGUP) after the sepecified time.

worker's process.exit() may not get called if your worker is too busy. scenario like, worker running into infinite loop due to a bug, waiting node.js debugger/inspector to close connection but it never reply. (process.exit() will choke with a message "Waiting for the debugger to disconnect..." for node 8.9.3
exit signal will never send to the workercluster. this caused sc-hot-reboot not work with arg inspect. as process.exit() will never reply causing respawn never happen. sc-hit-reboot use socketCluster.killWorkers(); which in will call process.exit() in scworker.js
