### PR TITLE
Avoid launching legacy debugger on child processes

### DIFF
--- a/index.js
+++ b/index.js
@@ -657,7 +657,6 @@ SocketCluster.prototype._launchWorkerCluster = function () {
     } else {
       inspectPort = argv['inspect-workers'];
     }
-    execOptions.execArgv.push('--debug-port=' + inspectPort);
     execOptions.execArgv.push('--inspect=' + inspectPort);
   }
 


### PR DESCRIPTION
Programs attempting to track and debug child processes via the WS protocol (such as VSCode) have trouble tracking keeping track if the legacy debugger is enabled.

This is primarily intended to fix VSCode launch configurations that use the `autoAttachChildProcesses` feature.