### PR TITLE
Prevent the sample from going into the npm package!

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 .gitignore
-sample/public/socketcluster.js
+sample
 test
 assets


### PR DESCRIPTION
Currently the socketcuster distro is 180.5MB, 159.2MB of that is in the sample/ directory which **recursively has npm packages within it.**

```
sample/ (122MB)
  node_modules/ (122.1MB)
    socketcluster/ (86MB)
      sample/ (86.2 MB)
    rxjs/ (20MB)
    lodash/ (5.1MB)
    ...
```