### PR TITLE
Revamp SocketCluster Protocol overview

### DIFF
--- a/socketcluster-protocol.md
+++ b/socketcluster-protocol.md
@@ -3,11 +3,11 @@
 ## Overview
 
 SocketCluster protocol is implemented on top of the WebSockets protocol and consists of multiple components:
-- Handshake
-- Connection health check (ping/pong)
-- Event layer
-- Pub/Sub layer
-- Authentication layer
+- [Handshake](#Handshake)
+- [Connection health check (ping/pong)](#Connection-health-check-(ping/pong))
+- [Event layer](#Event-layer)
+- [Pub/Sub layer](#Pub/Sub-layer)
+- [Authentication layer](#Authentication-layer)
 
 Minimal requirements for a simple SocketCluster compatible client are to implement:  
 Handshake, ping/pong and (at least partially) the Event layer.  
@@ -25,7 +25,7 @@ Pub/Sub and Authentication layers are completely optional.
 
 - In SocketCluster >=v15 `#disconnect` event is deprecated and no longer in use.  
 
-- Protocol V1 uses `'#1'` and `'#2'` for ping/pong
+- Protocol V1 uses `'#1'` and `'#2'` for [ping/pong](#Connection-health-check-(ping/pong))  
   Protocol V2 uses empty strings `''` for both.  
 
 - In Protocol V1 all event names starting with `'#'` are considered reserved for special control events.  
@@ -39,14 +39,14 @@ Protocol V1:
 - All event names starting with `'#'`  
 
 Protocol V2:  
-- `#handshake`
-- `#publish`
-- `#subscribe`
-- `#unsubscribe`
-- `#kickOut`
-- `#authenticate`
-- `#setAuthToken`
-- `#removeAuthToken`
+- [`#handshake`](#Handshake)
+- [`#publish`](#Publish)
+- [`#subscribe`](#Subscribe)
+- [`#unsubscribe`](#Unsubscribe)
+- [`#kickOut`](#Kick-out)
+- [`#authenticate`](#Authentication-event)
+- [`#setAuthToken`](#Token-acquisition)
+- [`#removeAuthToken`](#Deathentication)
 
 
 ### Call ID & Response ID
@@ -665,3 +665,9 @@ authError: {
   isBadToken: true
 }
 ```
+
+---
+
+Thank you for your time implementing custom SocketCluster client! :heart:  
+If you have completed one, please, open a pull request to add your client to the [list of SocketCluster clients](https://github.com/SocketCluster/client-drivers)  
+If you encounter any errors or have any questions, feel free to ask for help in [SocketCluster Gitter chat room](https://gitter.im/SocketCluster/socketcluster)  

--- a/socketcluster-protocol.md
+++ b/socketcluster-protocol.md
@@ -1,6 +1,4 @@
-# SocketCluster Protocol
-
-## Overview
+## SocketCluster Protocol Overview
 
 SocketCluster protocol is implemented on top of the WebSockets protocol and consists of multiple components:
 - [Handshake](#Handshake)
@@ -68,7 +66,6 @@ In your custom SocketCluster client you could use something like `UUID` strings 
 
 Some special events expect no response, hence `cid` for them is not required and ignored if present.  
 
----
 
 ## Handshake
 
@@ -118,7 +115,6 @@ If `cid` was not specified, `rid` will be omitted.
 }
 ```
 
----
 
 ## Connection health check (ping/pong)
 
@@ -137,7 +133,6 @@ For example, if a user's internet drops out suddenly, there would be no way to t
 
 \* \- In Protocol V2 `#disconnect` event is deprecated and no longer in use.
 
----
 
 ## Event layer
 
@@ -192,7 +187,7 @@ for await (const request of socket.procedure('procedureName')) {
 
 Transmitted events and RPC are similar in structure. They share the same property `event` for their names, but they are different entities.  
 In order to invoke a RPC, a SocketCluster client should send a RPC request.  
-Unlike transmitted events, every RPC request must include a unique `cid` (Call ID), because every RPC expects a RPC response with matching `rid` (Response ID) from another side of communication.  
+Unlike transmitted events, every RPC request must include a unique `cid` (Call ID), because every RPC request expects a RPC response with matching `rid` (Response ID) from another side of communication.  
 
 #### **RPC request** is a JSON-encoded string with the following structure:
 ```js
@@ -258,7 +253,6 @@ If no response with matching `rid` will be received from a client, the `socket.i
 Most of the [SocketCluster clients](https://github.com/SocketCluster/client-drivers) follow the same logic.  
 A SocketCluster client sets a timer (alike `setTimeout`) for each RPC sent, with consideration of `cid`. Those timers expose a `TimeoutError` when are finished. And if the client receives a RPC response with `rid` matching `cid` of one of the ongoing timers, the client destroys the timer before it fires up.
 
----
 
 ## Pub/Sub layer
 
@@ -432,7 +426,6 @@ In that case a SocketCluster client will receive a special `#kickOut` event. Or 
 }
 ```
 
----
 
 ## Authentication layer
 

--- a/socketcluster-protocol.md
+++ b/socketcluster-protocol.md
@@ -2,9 +2,9 @@
 
 SocketCluster protocol is implemented on top of the WebSockets protocol and consists of multiple components:
 - [Handshake](#Handshake)
-- [Connection health check (ping/pong)](#Connection-health-check-(ping/pong))
+- [Connection health check (ping/pong)](#Connection-health-check-pingpong)
 - [Event layer](#Event-layer)
-- [Pub/Sub layer](#Pub/Sub-layer)
+- [Pub/Sub layer](#PubSub-layer)
 - [Authentication layer](#Authentication-layer)
 
 Minimal requirements for a simple SocketCluster compatible client are to implement:  
@@ -23,7 +23,7 @@ Pub/Sub and Authentication layers are completely optional.
 
 - In SocketCluster >=v15 `#disconnect` event is deprecated and no longer in use.  
 
-- Protocol V1 uses `'#1'` and `'#2'` for [ping/pong](#Connection-health-check-(ping/pong))  
+- Protocol V1 uses `'#1'` and `'#2'` for [ping/pong](#Connection-health-check-pingpong)  
   Protocol V2 uses empty strings `''` for both.  
 
 - In Protocol V1 all event names starting with `'#'` are considered reserved for special control events.  


### PR DESCRIPTION
closes https://github.com/SocketCluster/socketcluster/issues/557

I’ve tried to revamp SocketCluster Protocol overview considering all the changes in the recent years.

I guess it's more meaningful to read as a whole document at
https://github.com/MegaGM/socketcluster/blob/docs-sc-protocol/socketcluster-protocol.md

Please, check if it's all right :ballot_box_with_check: